### PR TITLE
Reduce the number of allocations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,14 @@ version = "0.1.0"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
+FastGaussQuadrature = "1"
 ForwardDiff = "0.10"
 julia = "1"
-FastGaussQuadrature = "1"
-
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/QuadratureOnImplicitRegions.jl
+++ b/src/QuadratureOnImplicitRegions.jl
@@ -3,6 +3,7 @@ module QuadratureOnImplicitRegions
 
 using FastGaussQuadrature,LinearAlgebra,ForwardDiff
 
+import FiniteDiff.finite_difference_gradient! #non-allocating gradient
 
 export algoim_nodes_weights
 # export algoim_quad #nneds work

--- a/src/algoim.jl
+++ b/src/algoim.jl
@@ -92,9 +92,11 @@ function algoim_nodes_weights(ψ_list,s_list,U::Matrix{T},x_ref,w_ref,recursion_
             si_U=sgn(g[k],s_list[i],1);
 
 
-            new_ψ_list=vcat(new_ψ_list,ψ_L,ψ_U); 
-            new_s_list=vcat(new_s_list,si_L,si_U)
-            
+            # new_ψ_list=vcat(new_ψ_list,ψ_L,ψ_U); 
+            # new_s_list=vcat(new_s_list,si_L,si_U)
+            push!(new_ψ_list,ψ_L,ψ_U)
+            push!(new_s_list,si_L,si_U)
+
         else #subdivide the domain (unless it is too small)
             Volume=prod(U[2,:] - U[1,:]);
 

--- a/src/algoim.jl
+++ b/src/algoim.jl
@@ -70,10 +70,12 @@ function algoim_nodes_weights(ψ_list,s_list,U::Matrix{T},x_ref,w_ref,recursion_
 
         δ[:] .=fill(-Inf,d)
 
-        g[:] .=ForwardDiff.gradient(ψ,xc)
+        # g[:] .=ForwardDiff.gradient(ψ,xc)
+        finite_difference_gradient!(g,ψ,xc)
 
         for i in axes(Samples,2)
-            gtemp[:] .=ForwardDiff.gradient(ψ,Samples[:,i])
+            # gtemp[:] .=ForwardDiff.gradient(ψ,Samples[:,i])
+            finite_difference_gradient!(gtemp,ψ, @view Samples[:,i])
             for kk=1:d 
                 δ[kk]=max(δ[kk],abs(gtemp[kk]-g[kk]))
             end
@@ -134,11 +136,6 @@ function algoim_nodes_weights(ψ_list,s_list,U::Matrix{T},x_ref,w_ref,recursion_
     
     x_tilde,w_tilde=algoim_nodes_weights(new_ψ_list,new_s_list,U_tilde,x_ref,w_ref) #(d-1)xN  matrix 
 
-
-    N=size(x_tilde,2)
-    
-    w=Float64[]
-    x=Matrix{T}(undef,d,0)
 
     QQ=Vector{T}(undef,d-1)
 

--- a/src/algoim.jl
+++ b/src/algoim.jl
@@ -68,7 +68,8 @@ function algoim_nodes_weights(ψ_list,s_list,U::Matrix{T},x_ref,w_ref,recursion_
     for i in eachindex(s_list)
         ψ=ψ_list[i]
 
-        δ[:] .=fill(-Inf,d)
+        # δ[:] .=fill(-Inf,d)
+        fill!(δ,-Inf)
 
         # g[:] .=ForwardDiff.gradient(ψ,xc)
         finite_difference_gradient!(g,ψ,xc)

--- a/src/algoim_functions.jl
+++ b/src/algoim_functions.jl
@@ -1,5 +1,9 @@
 sgn(m,s,σ)= ( m==σ*s ? σ*m : 0.0)
 
+find_root(ψ::F,a::T,b::T) where {F,T<:Integer} = find_root(ψ,Float64(a),Float64(b))
+find_roots(ψ::F,a::T,b::T) where {F,T<:Integer} = find_roots(ψ,Float64(a),Float64(b))
+find_roots(ψ_list::Vector{F},a::T,b::T) where {F,T<:Integer} = find_roots(ψ_list,Float64(a),Float64(b))
+
 
 """
     find_root(ψ::F,a::T,b::T) 

--- a/src/algoim_functions.jl
+++ b/src/algoim_functions.jl
@@ -96,6 +96,33 @@ function shifted_gl!(x_ref::Vector{T},w_ref::Vector{T},a::T,b::T,x::Vector{T},w:
     return 
 end
 
+""" 
+    d1_count_subintervals(ψ_list,s_list,domain)
+
+Counts how many sub-intervals of domain satisfiy s_iψ_i≥0
+"""
+function  d1_count_subintervals(ψ_list,s_list,domain)
+    Z=find_roots(ψ_list,domain[1],domain[2])
+    cnt=0
+
+    n=length(Z)
+    for i=1:n-1
+        a=Z[i];b=Z[i+1];c=(a+b)/2
+
+        flag=true 
+        for i in eachindex(ψ_list) 
+            if s_list[i]*ψ_list[i](c)<0
+                flag=false;break;
+            end
+        end    
+        if flag
+            cnt+=1
+        end
+    end 
+
+    return cnt
+end
+
 
 """
     d1_case(ψ_list,s_list,domain,x_ref,w_ref)

--- a/src/algoim_functions.jl
+++ b/src/algoim_functions.jl
@@ -29,7 +29,7 @@ Returns multiple roots of ψ in the open interval `[a,b]`
 """
 function find_roots(ψ::F,a::T,b::T) where {F,T}
 
-    n=20 #split the interval [a,b] into n sub-intervals
+    n=10 #split the interval [a,b] into n sub-intervals
     h=(b-a)/n
     Z=Vector{Float64}(undef,0)
     for i=0:n-1
@@ -218,7 +218,7 @@ function remove_kth(x::T,k::I) where {I,T<:Number}
 end
 
 function insert_kth(x::V,k::I,t::T) where {I,V<:AbstractVector,T<:Number}
-    [x[1:k-1];t;x[k:end]]
+    [@view x[1:k-1];t;@view x[k:end]]
 end
 
 function insert_kth(x::N,k::I,t::S) where {N<:Number,I,S<:Number}


### PR DESCRIPTION
This is part of an ongoing process to reduce the number of allocations used by the main function. Since the number of nodes is not known in advance, I relied heavily on dynamically allocated vectors. 

In v0.1.0: The following 3-dimensional example returns 7000 nodes but uses 300K allocations. 

```julia 
using QuadratureOnImplicitRegions
using BenchmarkTools

ψ(x)=(x[1]^2+x[2]^2+x[3]^2)-1
a,b=zeros(3), ones(3)
@btime algoim_nodes_weights(ψ,-1.0, a,b,10)

# 11.908 ms (320559 allocations: 37.01 MiB)
```

This new version returns the same number of nodes but using 150K allocations, and it is twice as fast.
 

``` Julia
 # 5.354 ms (155959 allocations: 11.08 MiB)
```

**Breaking change:**  The nodes are now a $d\times N$ matrix, where $d$ is the dimension of the ambient space (each column is a node), instead of a vector of vectors. 

**Additional Dep:** I am using [FiniteDiff](https://docs.sciml.ai/FiniteDiff/stable/). I noticed that  `finite_difference_gradient!` from FiniteDiff uses less allocations than its counterpart from  `ForwardDiff` (I am not sure if this is the case always).
